### PR TITLE
Fix NPE on null dynamo values

### DIFF
--- a/src/main/java/com/citusdata/migration/DynamoDBTableReplicator.java
+++ b/src/main/java/com/citusdata/migration/DynamoDBTableReplicator.java
@@ -560,10 +560,11 @@ public class DynamoDBTableReplicator {
 			AttributeValue typedValue = entry.getValue();
 			TableColumnValue columnValue = columnValueFromDynamoValue(typedValue);
 
-			if (columnValue.type == column.type) {
+			if( columnValue == null ){
+				row.setValue(columnName, null);
+			}else if (columnValue.type == column.type) {
 				row.setValue(columnName, columnValue);
 			} else {
-
 				row.setValue(columnName + "_" + columnValue.type, columnValue);
 			}
 		}


### PR DESCRIPTION
If a table containes a row with a null value, we hit an NPE and the entire table migration fails. This *should* fix it